### PR TITLE
Add base HTML-to-text conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 converting HTML documents into Markdown format. The project aims to offer a
 simple API that can be embedded in other Crystal applications while also
 providing an easy to use binary for quick conversions on the command line.
+At this early stage the conversion only extracts the textual content from the
+HTML input. Future releases will add proper Markdown rendering of elements.
 
 The library is currently in its early planning stage. The documentation lays out
 the goals and how to contribute before any implementation begins.

--- a/docs/adr/0002-text-backbone.md
+++ b/docs/adr/0002-text-backbone.md
@@ -1,0 +1,19 @@
+# 2. Initial HTML to Markdown backbone
+
+Date: 2025-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+The project requires a starting point for converting HTML documents into Markdown. At this early stage we do not yet support individual HTML elements. We need a simple approach that allows incremental improvements while offering immediate value.
+
+## Decision
+
+Implement `Crhtml2markdown.convert` which takes an HTML string and returns the parsed document's textual content via `XML.parse_html(html).content`. This provides a minimal but functional conversion that strips markup and outputs plain text.
+
+## Consequences
+
+All HTML markup will be discarded in the first release. Future ADRs will document enhancements that map specific HTML elements to Markdown syntax.

--- a/spec/crhtml2markdown_spec.cr
+++ b/spec/crhtml2markdown_spec.cr
@@ -1,10 +1,8 @@
 require "./spec_helper"
 
 describe Crhtml2markdown do
-  # TODO: Write tests
-
-  it "works" do
-    # Placeholder test ensuring the spec suite runs
-    true.should eq(true)
+  it "converts HTML to text" do
+    html = "<p>Hello <strong>world</strong></p>"
+    Crhtml2markdown.convert(html).should eq("Hello world")
   end
 end

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -1,6 +1,15 @@
+require "xml"
+
 # TODO: Write documentation for `Crhtml2markdown`
 module Crhtml2markdown
   VERSION = "0.1.0"
 
-  # TODO: Put your code here
+  # Converts the provided HTML string into Markdown.
+  #
+  # The initial implementation simply extracts the textual content of the
+  # document. Future versions will gradually add proper Markdown conversion of
+  # individual HTML elements.
+  def self.convert(html : String) : String
+    XML.parse_html(html).content
+  end
 end


### PR DESCRIPTION
## Summary
- implement `Crhtml2markdown.convert` that extracts text
- document early limitation in README
- add basic spec
- document decision in ADR

## Testing
- `crystal tool format`
- `crystal spec`


------
https://chatgpt.com/codex/tasks/task_e_6841a7d05074833192ad7cf3f91ea4b7