### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Crystal CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+      - name: Install dependencies
+        run: shards install
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Run specs
+        run: crystal spec

--- a/docs/adr/0003-github-ci.md
+++ b/docs/adr/0003-github-ci.md
@@ -1,0 +1,19 @@
+# 3. GitHub Actions for Crystal
+
+Date: 2025-06-06
+
+## Status
+
+Accepted
+
+## Context
+
+The project currently requires developers to run `crystal tool format` and `crystal spec` manually before submitting changes. Automating these checks ensures consistent formatting and passing tests for every contribution.
+
+## Decision
+
+Set up a GitHub Actions workflow that installs Crystal, runs the formatter in check mode, and executes the specs on each push and pull request.
+
+## Consequences
+
+Formatting and spec failures will cause the workflow to fail, preventing unformatted or broken code from being merged. Contributors will get immediate feedback via CI.


### PR DESCRIPTION
## Summary
- enable CI using `crystal tool format --check` and `crystal spec`
- document the CI decision via ADR

## Testing
- `crystal tool format --check`
- `crystal spec`


------
https://chatgpt.com/codex/tasks/task_e_6841a924bfdc8331bd56a4979d3489c4