### PR TITLE
Add ameba lint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Crystal CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+      - name: Install dependencies
+        run: shards install
+      - name: Lint with ameba
+        run: ./bin/ameba
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Run specs
+        run: crystal spec

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 converting HTML documents into Markdown format. The project aims to offer a
 simple API that can be embedded in other Crystal applications while also
 providing an easy to use binary for quick conversions on the command line.
+At this early stage the conversion only extracts the textual content from the
+HTML input. Future releases will add proper Markdown rendering of elements.
 
 The library is currently in its early planning stage. The documentation lays out
 the goals and how to contribute before any implementation begins.
@@ -51,7 +53,8 @@ crystal spec
 ```
 
 Code style follows Crystal's formatter. Run `crystal tool format` before
-submitting patches.
+submitting patches. Static analysis is performed with `ameba`, run `./bin/ameba`
+after installing dependencies.
 
 Architecture Decision Records are kept in `docs/adr`. Please consult existing
 records and create a new one if your change introduces new decisions.

--- a/docs/adr/0002-text-backbone.md
+++ b/docs/adr/0002-text-backbone.md
@@ -1,0 +1,19 @@
+# 2. Initial HTML to Markdown backbone
+
+Date: 2025-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+The project requires a starting point for converting HTML documents into Markdown. At this early stage we do not yet support individual HTML elements. We need a simple approach that allows incremental improvements while offering immediate value.
+
+## Decision
+
+Implement `Crhtml2markdown.convert` which takes an HTML string and returns the parsed document's textual content via `XML.parse_html(html).content`. This provides a minimal but functional conversion that strips markup and outputs plain text.
+
+## Consequences
+
+All HTML markup will be discarded in the first release. Future ADRs will document enhancements that map specific HTML elements to Markdown syntax.

--- a/docs/adr/0003-github-ci.md
+++ b/docs/adr/0003-github-ci.md
@@ -1,0 +1,19 @@
+# 3. GitHub Actions for Crystal
+
+Date: 2025-06-06
+
+## Status
+
+Accepted
+
+## Context
+
+The project currently requires developers to run `crystal tool format` and `crystal spec` manually before submitting changes. Automating these checks ensures consistent formatting and passing tests for every contribution.
+
+## Decision
+
+Set up a GitHub Actions workflow that installs Crystal, runs the formatter in check mode, and executes the specs on each push and pull request.
+
+## Consequences
+
+Formatting and spec failures will cause the workflow to fail, preventing unformatted or broken code from being merged. Contributors will get immediate feedback via CI.

--- a/docs/adr/0004-introduce-ameba-linter.md
+++ b/docs/adr/0004-introduce-ameba-linter.md
@@ -1,0 +1,19 @@
+# 4. Introduce ameba for linting
+
+Date: 2025-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+We want to enforce consistent code style and catch issues early using static analysis.
+
+## Decision
+
+Add the `ameba` linter as a development dependency in `shard.yml` and run it as part of development checks.
+
+## Consequences
+
+Developers can run `./bin/ameba` after installing dependencies to lint the code. The current codebase contains some TODO comments that trigger warnings which can be addressed later.

--- a/docs/adr/0005-include-ameba-in-ci.md
+++ b/docs/adr/0005-include-ameba-in-ci.md
@@ -1,0 +1,19 @@
+# 5. Include ameba in CI pipeline
+
+Date: 2025-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+After introducing the `ameba` linter for development, we want the same checks run automatically in continuous integration to prevent style issues from entering the codebase.
+
+## Decision
+
+Extend the GitHub Actions workflow to execute `./bin/ameba` after installing dependencies.
+
+## Consequences
+
+Pull requests will fail if linting errors are detected, encouraging contributors to fix issues locally before submitting changes.

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,6 @@
+version: 2.0
+shards:
+  ameba:
+    git: https://github.com/crystal-ameba/ameba.git
+    version: 1.7.0-dev+git.commit.d861f4ed0f904e0ecdad11c26f98e968f7d95afa
+

--- a/shard.yml
+++ b/shard.yml
@@ -11,3 +11,8 @@ targets:
 crystal: '>= 1.16.2'
 
 license: MIT
+
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    branch: master

--- a/spec/crhtml2markdown_spec.cr
+++ b/spec/crhtml2markdown_spec.cr
@@ -1,10 +1,8 @@
 require "./spec_helper"
 
 describe Crhtml2markdown do
-  # TODO: Write tests
-
-  it "works" do
-    # Placeholder test ensuring the spec suite runs
-    true.should eq(true)
+  it "converts HTML to text" do
+    html = "<p>Hello <strong>world</strong></p>"
+    Crhtml2markdown.convert(html).should eq("Hello world")
   end
 end

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -1,6 +1,6 @@
 require "xml"
 
-# TODO: Write documentation for `Crhtml2markdown`
+# Provides HTML to Markdown conversion utilities
 module Crhtml2markdown
   VERSION = "0.1.0"
 

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -1,6 +1,15 @@
+require "xml"
+
 # TODO: Write documentation for `Crhtml2markdown`
 module Crhtml2markdown
   VERSION = "0.1.0"
 
-  # TODO: Put your code here
+  # Converts the provided HTML string into Markdown.
+  #
+  # The initial implementation simply extracts the textual content of the
+  # document. Future versions will gradually add proper Markdown conversion of
+  # individual HTML elements.
+  def self.convert(html : String) : String
+    XML.parse_html(html).content
+  end
 end


### PR DESCRIPTION
## Summary
- merge changes from main including CI workflow and earlier ADRs
- rename ameba ADR to `0004` to avoid numbering conflict
- add ameba linting to the GitHub Actions workflow
- document this change in ADR `0005`

## Testing
- `crystal spec`
- `./bin/ameba` *(fails: DocumentationAdmonition warning)*

------
https://chatgpt.com/codex/tasks/task_e_6841a851ed2c833186528016f685fd68