### PR TITLE
Add heading support

### DIFF
--- a/docs/adr/0005-element-converter-classes.md
+++ b/docs/adr/0005-element-converter-classes.md
@@ -1,0 +1,32 @@
+# 5. Element converter classes
+
+Date: 2025-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+As the converter starts supporting more HTML elements, placing all rendering
+logic in a single method becomes hard to maintain. The project needs a
+composable approach that allows adding new element handling without cluttering
+the core API.
+
+## Decision
+
+Introduce a small hierarchy of *element converter* classes. Each converter knows
+how to render a specific type of HTML node. `Crhtml2markdown.convert` traverses
+the parsed document and delegates rendering of a node to the first converter
+that reports it can handle the node. For now the library provides:
+
+- `HeadingConverter` for `h1`-`h6` elements
+- `TextConverter` for plain text nodes
+
+Additional converters will be added as support grows for other elements.
+
+## Consequences
+
+Rendering logic is split into small classes that can be tested and extended
+independently. The main module remains simple, merely orchestrating traversal
+and delegation to converters.

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,2 @@
+version: 2.0
+shards: {}

--- a/spec/crhtml2markdown_spec.cr
+++ b/spec/crhtml2markdown_spec.cr
@@ -5,4 +5,17 @@ describe Crhtml2markdown do
     html = "<p>Hello <strong>world</strong></p>"
     Crhtml2markdown.convert(html).should eq("Hello world")
   end
+
+  it "converts headings to markdown" do
+    html = "" +
+           "<h1>Heading 1</h1>\n" +
+           "<h2>Heading 2</h2>\n" +
+           "<h3>Heading 3</h3>\n" +
+           "<h4>Heading 4</h4>\n" +
+           "<h5>Heading 5</h5>\n" +
+           "<h6>Heading 6</h6>"
+
+    expected = "# Heading 1\n\n## Heading 2\n\n### Heading 3\n\n#### Heading 4\n\n##### Heading 5\n\n###### Heading 6"
+    Crhtml2markdown.convert(html).should eq(expected)
+  end
 end

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -1,15 +1,36 @@
 require "xml"
 
+require "./crhtml2markdown/converters/element_converter"
+require "./crhtml2markdown/converters/heading_converter"
+require "./crhtml2markdown/converters/text_converter"
+
 # TODO: Write documentation for `Crhtml2markdown`
 module Crhtml2markdown
   VERSION = "0.1.0"
 
+  @@converters = [
+    HeadingConverter.new,
+    TextConverter.new,
+  ]
+
   # Converts the provided HTML string into Markdown.
   #
-  # The initial implementation simply extracts the textual content of the
-  # document. Future versions will gradually add proper Markdown conversion of
-  # individual HTML elements.
+  # Individual HTML elements are handled by dedicated converter classes.
+  # Currently only headings (`h1`-`h6`) and plain text nodes are supported.
   def self.convert(html : String) : String
-    XML.parse_html(html).content
+    doc = XML.parse_html(html)
+    body = doc.xpath_node("//body") || doc
+
+    String.build do |io|
+      convert_node body, io
+    end.strip
+  end
+
+  private def self.convert_node(node : XML::Node, io : IO)
+    if converter = @@converters.find(&.handles?(node))
+      converter.convert(node, io)
+    else
+      node.children.each { |child| convert_node child, io }
+    end
   end
 end

--- a/src/crhtml2markdown/converters/element_converter.cr
+++ b/src/crhtml2markdown/converters/element_converter.cr
@@ -1,0 +1,6 @@
+module Crhtml2markdown
+  abstract class ElementConverter
+    abstract def handles?(node : XML::Node) : Bool
+    abstract def convert(node : XML::Node, io : IO) : Nil
+  end
+end

--- a/src/crhtml2markdown/converters/heading_converter.cr
+++ b/src/crhtml2markdown/converters/heading_converter.cr
@@ -1,0 +1,27 @@
+module Crhtml2markdown
+  class HeadingConverter < ElementConverter
+    def handles?(node : XML::Node) : Bool
+      heading_level(node.name) != nil
+    end
+
+    def convert(node : XML::Node, io : IO) : Nil
+      level = heading_level(node.name)
+      return unless level
+
+      text = node.content.strip
+      io << "#" * level << " " << text << "\n\n"
+    end
+
+    private def heading_level(name : String) : Int32?
+      case name
+      when "h1" then 1
+      when "h2" then 2
+      when "h3" then 3
+      when "h4" then 4
+      when "h5" then 5
+      when "h6" then 6
+      else           nil
+      end
+    end
+  end
+end

--- a/src/crhtml2markdown/converters/text_converter.cr
+++ b/src/crhtml2markdown/converters/text_converter.cr
@@ -1,0 +1,12 @@
+module Crhtml2markdown
+  class TextConverter < ElementConverter
+    def handles?(node : XML::Node) : Bool
+      node.text?
+    end
+
+    def convert(node : XML::Node, io : IO) : Nil
+      text = node.content
+      io << text unless text.strip.empty?
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement first step of element support plan for `h1`-`h6`
- skip whitespace-only text nodes
- test heading conversion

## Testing
- `crystal tool format`
- `crystal spec`


------
https://chatgpt.com/codex/tasks/task_e_6841ad5fe9248331b47c0cae844b7c72