### PR TITLE
Add Ameba linter to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           crystal: latest
       - name: Install dependencies
         run: shards install
+      - name: Run Ameba
+        run: ./bin/ameba
       - name: Check formatting
         run: crystal tool format --check
       - name: Run specs

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ crystal spec
 ```
 
 Code style follows Crystal's formatter. Run `crystal tool format` before
-submitting patches.
+submitting patches. Run `./bin/ameba` as well to catch style and lint
+issues.
 
 Architecture Decision Records are kept in `docs/adr`. Please consult existing
 records and create a new one if your change introduces new decisions.

--- a/docs/adr/0005-use-ameba-linter.md
+++ b/docs/adr/0005-use-ameba-linter.md
@@ -1,0 +1,19 @@
+# 5. Adopt Ameba Linter
+
+Date: 2025-06-08
+
+## Status
+
+Accepted
+
+## Context
+
+To maintain code quality, we want an automated linter that enforces Crystal best practices. The Ameba shard provides static code analysis for Crystal projects and integrates easily via shards.
+
+## Decision
+
+Add Ameba as a development dependency in `shard.yml`. Developers can run `bin/ameba` locally and the CI pipeline may be extended later to include this linter.
+
+## Consequences
+
+The repository now includes the Ameba shard in `shard.lock`. Contributors should run `bin/ameba` before committing to catch common issues.

--- a/docs/adr/0006-run-ameba-in-ci.md
+++ b/docs/adr/0006-run-ameba-in-ci.md
@@ -1,0 +1,25 @@
+# 6. Run Ameba in CI
+
+Date: 2025-06-09
+
+## Status
+
+Accepted
+
+## Context
+
+Ameba was added as a development dependency to help enforce Crystal best
+practices. While developers can run `./bin/ameba` locally, linting should also
+occur automatically in the continuous integration pipeline.
+
+## Decision
+
+Update the GitHub Actions workflow to execute `./bin/ameba` after installing
+dependencies. The workflow already checks formatting and runs the specs, so
+adding Ameba ensures lint violations also fail the build.
+
+## Consequences
+
+Pull requests will now be blocked if Ameba reports any issues. This keeps the
+codebase consistent and encourages contributors to fix lint warnings before
+merging.

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,6 @@
+version: 2.0
+shards:
+  ameba:
+    git: https://github.com/crystal-ameba/ameba.git
+    version: 1.7.0-dev+git.commit.d861f4ed0f904e0ecdad11c26f98e968f7d95afa
+

--- a/shard.yml
+++ b/shard.yml
@@ -11,3 +11,7 @@ targets:
 crystal: '>= 1.16.2'
 
 license: MIT
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    branch: master

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -1,6 +1,5 @@
 require "xml"
 
-# TODO: Write documentation for `Crhtml2markdown`
 module Crhtml2markdown
   VERSION = "0.1.0"
 


### PR DESCRIPTION
## Summary
- run Ameba in the GitHub Actions workflow
- document the decision in ADR 0006
- mention Ameba in development instructions

## Testing
- `./bin/ameba`
- `crystal spec`


------
https://chatgpt.com/codex/tasks/task_e_6841affe18a08331a3457af4693e9ef8