### PR TITLE
Add CLI executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore compiled shards and other artifacts
 /lib/
 /bin/
+!/bin/
+!/bin/crhtml2markdown
 /.shards/
 *.dwarf

--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ require "crhtml2markdown"
 markdown = Crhtml2markdown.convert("<p>Hello</p>")
 ```
 
-The project will also expose a command line interface:
+The project provides a command line interface:
 
 ```bash
 $ crhtml2markdown input.html > output.md
 ```
 
-The binary is not yet implemented but these examples illustrate the intended
-workflow.
 
 ## Development
 

--- a/bin/crhtml2markdown
+++ b/bin/crhtml2markdown
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+DIR="$(dirname "$0")"
+exec crystal run "$DIR/../src/crhtml2markdown/cli.cr" -- "$@"

--- a/docs/adr/0006-cli-entrypoint.md
+++ b/docs/adr/0006-cli-entrypoint.md
@@ -1,0 +1,29 @@
+# 6. Command line interface
+
+Date: 2025-06-08
+
+## Status
+
+Accepted
+
+## Context
+
+The project aims to provide both a library and a command line utility. While the
+core conversion API exists, there is no executable that users can invoke from
+the terminal. A small CLI wrapper is needed to parse options, read input and
+print the converted Markdown.
+
+## Decision
+
+Implement `Crhtml2markdown::CLI` under `src/crhtml2markdown/cli.cr`.
+The CLI parses `--help` and accepts an optional file argument. When a filename
+is provided the HTML is read from that file; otherwise STDIN is consumed. The
+result of `Crhtml2markdown.convert` is printed to STDOUT. A shell script
+`bin/crhtml2markdown` runs the CLI via `crystal run`. The shard's `targets`
+section is updated so the executable can be built with `shards build`.
+
+## Consequences
+
+Users can now run `crhtml2markdown` directly to convert HTML documents.
+Future enhancements can extend the option parser without affecting the library
+API.

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 targets:
   crhtml2markdown:
-    main: src/crhtml2markdown.cr
+    main: src/crhtml2markdown/cli.cr
 
 crystal: '>= 1.16.2'
 

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -1,0 +1,29 @@
+require "./spec_helper"
+
+private def run_cli(args : Array(String), input = "")
+  output = IO::Memory.new
+  Process.run("#{__DIR__}/../bin/crhtml2markdown", args, input: IO::Memory.new(input), output: output)
+  output.to_s
+end
+
+describe "crhtml2markdown CLI" do
+  it "reads from a file" do
+    dir = Dir.tempdir
+    path = File.join(dir, "input.html")
+    File.write(path, "<h1>Title</h1>")
+    begin
+      run_cli([path]).strip.should eq("# Title")
+    ensure
+      File.delete(path)
+    end
+  end
+
+  it "reads from STDIN" do
+    run_cli([] of String, "<h1>Title</h1>").strip.should eq("# Title")
+  end
+
+  it "prints help" do
+    output = run_cli(["--help"])
+    output.should contain("Usage: crhtml2markdown")
+  end
+end

--- a/src/crhtml2markdown/cli.cr
+++ b/src/crhtml2markdown/cli.cr
@@ -1,0 +1,31 @@
+require "option_parser"
+require "../crhtml2markdown"
+
+module Crhtml2markdown
+  module CLI
+    def self.run(args = ARGV)
+      show_help = false
+
+      parser = OptionParser.parse(args) do |p|
+        p.banner = "Usage: crhtml2markdown [options] [file]"
+        p.on("-h", "--help", "Show this help") { show_help = true }
+      end
+
+      if show_help
+        puts parser
+        return
+      end
+
+      filename = args.shift?
+      html = if filename
+               File.read(filename)
+             else
+               STDIN.gets_to_end
+             end
+
+      puts Crhtml2markdown.convert(html)
+    end
+  end
+end
+
+Crhtml2markdown::CLI.run


### PR DESCRIPTION
## Summary
- add CLI module for converting files or stdin to Markdown
- expose bin/crhtml2markdown entrypoint
- document command line interface in README
- update shard target to use CLI
- log new ADR about CLI design
- test command-line behaviour with integration specs

## Testing
- `crystal tool format`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_6841d896cbb48331ae2bf6e2af97cc3b