### PR TITLE
Implement paragraph, emphasis, and link converters

### DIFF
--- a/docs/adr/0007-expose-convert-node.md
+++ b/docs/adr/0007-expose-convert-node.md
@@ -1,0 +1,28 @@
+# 7. Expose `convert_node` for nested element rendering
+
+Date: 2025-06-09
+
+## Status
+
+Accepted
+
+## Context
+
+`Crhtml2markdown` delegates rendering of HTML nodes to small converter classes.
+Initially, converter implementations only needed the raw text of a node. As the
+library starts supporting nested elements like paragraphs and emphasis, a
+converter must be able to process its children using the same dispatch logic as
+the root renderer.
+
+## Decision
+
+Move `convert_node` from a private module method to a public one so that element
+converters can call it when rendering their child nodes. This keeps the
+conversion logic centralized while allowing converters to nest other elements.
+
+## Consequences
+
+Converters such as `ParagraphConverter`, `EmphasisConverter`, and
+`LinkConverter` invoke `Crhtml2markdown.convert_node` to render their children.
+Although this exposes an internal helper, it simplifies converter
+implementations and enables proper Markdown output for nested HTML.

--- a/spec/crhtml2markdown_spec.cr
+++ b/spec/crhtml2markdown_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Crhtml2markdown do
   it "converts HTML to text" do
     html = "<p>Hello <strong>world</strong></p>"
-    Crhtml2markdown.convert(html).should eq("Hello world")
+    Crhtml2markdown.convert(html).should eq("Hello **world**")
   end
 
   it "converts headings to markdown" do
@@ -17,5 +17,20 @@ describe Crhtml2markdown do
 
     expected = "# Heading 1\n\n## Heading 2\n\n### Heading 3\n\n#### Heading 4\n\n##### Heading 5\n\n###### Heading 6"
     Crhtml2markdown.convert(html).should eq(expected)
+  end
+
+  it "converts paragraphs" do
+    html = "<p>Hello</p><p>World</p>"
+    Crhtml2markdown.convert(html).should eq("Hello\n\nWorld")
+  end
+
+  it "converts emphasis" do
+    html = "<p>This is <em>important</em> and <strong>bold</strong></p>"
+    Crhtml2markdown.convert(html).should eq("This is *important* and **bold**")
+  end
+
+  it "converts links" do
+    html = "<p>Visit <a href='https://example.com'>Example</a>.</p>"
+    Crhtml2markdown.convert(html).should eq("Visit [Example](https://example.com).")
   end
 end

--- a/src/crhtml2markdown.cr
+++ b/src/crhtml2markdown.cr
@@ -2,6 +2,9 @@ require "xml"
 
 require "./crhtml2markdown/converters/element_converter"
 require "./crhtml2markdown/converters/heading_converter"
+require "./crhtml2markdown/converters/paragraph_converter"
+require "./crhtml2markdown/converters/emphasis_converter"
+require "./crhtml2markdown/converters/link_converter"
 require "./crhtml2markdown/converters/text_converter"
 
 # TODO: Write documentation for `Crhtml2markdown`
@@ -10,6 +13,9 @@ module Crhtml2markdown
 
   @@converters = [
     HeadingConverter.new,
+    ParagraphConverter.new,
+    EmphasisConverter.new,
+    LinkConverter.new,
     TextConverter.new,
   ]
 
@@ -26,7 +32,7 @@ module Crhtml2markdown
     end.strip
   end
 
-  private def self.convert_node(node : XML::Node, io : IO)
+  def self.convert_node(node : XML::Node, io : IO)
     if converter = @@converters.find(&.handles?(node))
       converter.convert(node, io)
     else

--- a/src/crhtml2markdown/converters/emphasis_converter.cr
+++ b/src/crhtml2markdown/converters/emphasis_converter.cr
@@ -1,0 +1,14 @@
+module Crhtml2markdown
+  class EmphasisConverter < ElementConverter
+    def handles?(node : XML::Node) : Bool
+      node.name == "em" || node.name == "strong"
+    end
+
+    def convert(node : XML::Node, io : IO) : Nil
+      marker = node.name == "strong" ? "**" : "*"
+      io << marker
+      node.children.each { |child| Crhtml2markdown.convert_node(child, io) }
+      io << marker
+    end
+  end
+end

--- a/src/crhtml2markdown/converters/link_converter.cr
+++ b/src/crhtml2markdown/converters/link_converter.cr
@@ -1,0 +1,15 @@
+module Crhtml2markdown
+  class LinkConverter < ElementConverter
+    def handles?(node : XML::Node) : Bool
+      node.name == "a" && !!node["href"]?
+    end
+
+    def convert(node : XML::Node, io : IO) : Nil
+      href = node["href"]
+      text = String.build do |inner|
+        node.children.each { |child| Crhtml2markdown.convert_node(child, inner) }
+      end
+      io << "[" << text << "](#{href})"
+    end
+  end
+end

--- a/src/crhtml2markdown/converters/paragraph_converter.cr
+++ b/src/crhtml2markdown/converters/paragraph_converter.cr
@@ -1,0 +1,12 @@
+module Crhtml2markdown
+  class ParagraphConverter < ElementConverter
+    def handles?(node : XML::Node) : Bool
+      node.name == "p"
+    end
+
+    def convert(node : XML::Node, io : IO) : Nil
+      node.children.each { |child| Crhtml2markdown.convert_node(child, io) }
+      io << "\n\n"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- convert nested nodes via a public `convert_node` helper
- support `<p>`, `<em>/<strong>` and `<a>` elements
- document the design change in ADR-7
- test paragraphs, emphasis and links

## Testing
- `crystal tool format`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_6841eb28f06483318d1ac32d2b72d0b5